### PR TITLE
Scale and Drawable Update

### DIFF
--- a/app/src/main/java/mas/german/landingplanes/MainActivity.java
+++ b/app/src/main/java/mas/german/landingplanes/MainActivity.java
@@ -17,7 +17,5 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         mView = (AerodromeView) findViewById(R.id.view_aerodrome);
         mView.setController(mController);
-
-        mGame.initialize();
     }
 }

--- a/app/src/main/java/mas/german/landingplanes/controller/Controller.java
+++ b/app/src/main/java/mas/german/landingplanes/controller/Controller.java
@@ -22,4 +22,9 @@ public class Controller implements AerodromeView.OnViewEventListener {
       mGame.orientateSelectedAircraft(position);
     }
   }
+
+  @Override
+  public void onViewReady() {
+    mGame.initialize();
+  }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/AerodromeView.java
+++ b/app/src/main/java/mas/german/landingplanes/view/AerodromeView.java
@@ -37,6 +37,11 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
      * @param position  The position in Aerodrome Coordinates that the Aircraft needs to point to.
      */
     void onAerodromeTapped(Position position);
+
+    /**
+     * Notify the listeners that the view is ready to be used.
+     */
+    void onViewReady();
   }
 
   public void setController(OnViewEventListener controller) {
@@ -59,6 +64,7 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
   // Aerodrome Matrix used to fit the model into the view.
   private Matrix mAerodrome = new Matrix();
   private boolean mIsAerodromeLoaded = false;
+  private float mScale = 1f;
 
   // Map of Aircraft Drawables. They represent the aircraft from the model.
   private Map<Integer, AircraftDrawable> mDrawables = new HashMap<>();
@@ -104,12 +110,19 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
   /**
    * Auxiliary method used to scale the Aerodrome Matrix in order to fit the screen.
    * Note that this method is only called once, as the view's size is constant throughout the game.
+   * This Matrix helps mapping between Aerodrome and Canvas Coordinates.
    */
   private void prepareAerodrome() {
     float scaleX = getWidth() / (float) (mGame.getAerodrome().getWidth());
     float scaleY = getHeight() / (float) (mGame.getAerodrome().getHeight());
     mAerodrome.postScale(scaleX, scaleY);
     mIsAerodromeLoaded = true;
+    // Since the Aerodrome is square, either scale can be used. Should the aerodrome be rectangular,
+    // the scale would have to be chosen in order to fit the aerodrome in the screen.
+    mScale = scaleX;
+    if (mController != null) {
+      mController.onViewReady();
+    }
   }
 
   /**
@@ -133,9 +146,6 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
     if (!mIsAerodromeLoaded) {
       prepareAerodrome();
     }
-
-    // Concatenate the Canvas with the Aerodrome Matrix.
-    canvas.concat(mAerodrome);
 
     // Draw the Aerodrome's Background.
     canvas.drawRect(0, 0, getWidth(), getHeight(), mBackgroundPaint);
@@ -191,23 +201,23 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
 
   @Override
   public void onLongRunwayCreated(LongRunway longRunway) {
-    mSiteDrawables.add(new LongRunwayDrawable(mContext, longRunway));
+    mSiteDrawables.add(new LongRunwayDrawable(mContext, mScale, longRunway));
   }
 
   @Override
   public void onShortRunwayCreated(ShortRunway shortRunway) {
-    mSiteDrawables.add(new ShortRunwayDrawable(mContext, shortRunway));
+    mSiteDrawables.add(new ShortRunwayDrawable(mContext, mScale, shortRunway));
   }
 
   @Override
   public void onHelipadCreated(Helipad helipad) {
-    mSiteDrawables.add(new HelipadDrawable(mContext, helipad));
+    mSiteDrawables.add(new HelipadDrawable(mContext, mScale, helipad));
   }
 
   @Override
   public void onLargePlaneGenerated(LargePlane largePlane) {
     synchronized (mDrawables.values()) {
-      mDrawables.put(largePlane.getId(), new LargePlaneDrawable(mContext, largePlane));
+      mDrawables.put(largePlane.getId(), new LargePlaneDrawable(mContext, mScale, largePlane));
     }
     postInvalidate();
   }
@@ -215,7 +225,7 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
   @Override
   public void onLightPlaneGenerated(LightPlane lightPlane) {
     synchronized (mDrawables.values()) {
-      mDrawables.put(lightPlane.getId(), new LightPlaneDrawable(mContext, lightPlane));
+      mDrawables.put(lightPlane.getId(), new LightPlaneDrawable(mContext, mScale, lightPlane));
     }
     postInvalidate();
   }
@@ -223,7 +233,7 @@ public class AerodromeView extends ImageView implements Game.EventsListener {
   @Override
   public void onHelicopterGenerated(Helicopter helicopter) {
     synchronized (mDrawables.values()) {
-      mDrawables.put(helicopter.getId(), new HelicopterDrawable(mContext, helicopter));
+      mDrawables.put(helicopter.getId(), new HelicopterDrawable(mContext, mScale, helicopter));
     }
     postInvalidate();
   }

--- a/app/src/main/java/mas/german/landingplanes/view/HelicopterDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/HelicopterDrawable.java
@@ -10,10 +10,8 @@ import mas.german.landingplanes.aircrafts.Aircraft;
 public class HelicopterDrawable extends AircraftDrawable {
   private static final String TAG = HelicopterDrawable.class.getSimpleName();
 
-  HelicopterDrawable(Context context, Aircraft aircraft) {
-    setId(aircraft.getId());
-    setPosition(aircraft.getPosition());
-    setRadius(aircraft.getRadius());
-    setPaintColor(context.getResources().getColor(R.color.helicopter));
+  HelicopterDrawable(Context context, float scale, Aircraft aircraft) {
+    super(aircraft.getId(), aircraft.getPosition(), aircraft.getRadius(), aircraft.getDirection(),
+        scale, context.getResources().getColor(R.color.helicopter));
   }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/HelipadDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/HelipadDrawable.java
@@ -11,16 +11,15 @@ import mas.german.landingplanes.landingsites.Helipad;
 public class HelipadDrawable extends LandingSiteDrawable {
   private static final String TAG = HelipadDrawable.class.getSimpleName();
 
-  HelipadDrawable(Context context, Helipad runway) {
-    setPosition(runway.getPosition());
-    setPaintColor(context.getResources().getColor(R.color.landingSite));
+  HelipadDrawable(Context context, float scale, Helipad runway) {
+    super(scale, runway.getPosition(), context.getResources().getColor(R.color.landingSite));
   }
 
   @Override
   public void draw(Canvas canvas) {
     canvas.save();
-    canvas.drawCircle((float) getPosition().getX(), (float) getPosition().getY(), WIDTH/2,
-        getPaint());
+    canvas.drawCircle((float) getPosition().getX(), (float) getPosition().getY(),
+        getMeasurement() / 2, getPaint());
     canvas.restore();
   }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/LandingSiteDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/LandingSiteDrawable.java
@@ -11,19 +11,32 @@ import mas.german.landingplanes.Position;
  */
 public abstract class LandingSiteDrawable extends Drawable {
   private static final String TAG = LandingSiteDrawable.class.getSimpleName();
-  // Width measure in Aerodrome Units.
-  protected static final float WIDTH = 6f;
+  // Main measurement in Aerodrome Coordinates. This represents the width of runways and radius of
+  // helipads.
+  protected static final float MAIN_MEASUREMENT = 6f;
 
-  // Entrance Position of the Landing Site.
+  // Entrance Position of the Landing Site, in Canvas Coordinates.
   private float mX;
   private float mY;
 
   // Paint to represent the Landing Site.
   private Paint mPaint;
 
+  // Scale to convert from Aerodrome Coordinates into Canvas Coordinates.
+  private float mScale = 1f;
+
+  LandingSiteDrawable(float scale, Position position, int color) {
+    mScale = scale;
+    mX = (float) position.getX() * scale;
+    mY = (float) position.getY() * scale;
+    mPaint = new Paint();
+    mPaint.setStyle(Paint.Style.FILL);
+    mPaint.setColor(color);
+  }
+
   protected void setPosition(Position position) {
-    mX = (float) position.getX();
-    mY = (float) position.getY();
+    mX = (float) position.getX() * mScale;
+    mY = (float) position.getY() * mScale;
   }
 
   protected Paint getPaint() {
@@ -34,10 +47,11 @@ public abstract class LandingSiteDrawable extends Drawable {
     return new Position(mX, mY);
   }
 
-  protected void setPaintColor(int color) {
-    mPaint = new Paint();
-    mPaint.setStyle(Paint.Style.FILL);
-    mPaint.setColor(color);
+  /**
+   * Get the main measurement of the landing site in Canvas Coordinates.
+   */
+  protected float getMeasurement() {
+    return MAIN_MEASUREMENT * mScale;
   }
 
   @Override

--- a/app/src/main/java/mas/german/landingplanes/view/LargePlaneDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/LargePlaneDrawable.java
@@ -10,10 +10,8 @@ import mas.german.landingplanes.aircrafts.Aircraft;
 public class LargePlaneDrawable extends AircraftDrawable {
   private static final String TAG = LargePlaneDrawable.class.getSimpleName();
 
-  LargePlaneDrawable(Context context, Aircraft aircraft) {
-    setId(aircraft.getId());
-    setPosition(aircraft.getPosition());
-    setRadius(aircraft.getRadius());
-    setPaintColor(context.getResources().getColor(R.color.largeAircraft));
+  LargePlaneDrawable(Context context, float scale, Aircraft aircraft) {
+    super(aircraft.getId(), aircraft.getPosition(), aircraft.getRadius(), aircraft.getDirection(),
+        scale, context.getResources().getColor(R.color.largeAircraft));
   }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/LightPlaneDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/LightPlaneDrawable.java
@@ -10,10 +10,8 @@ import mas.german.landingplanes.aircrafts.Aircraft;
 public class LightPlaneDrawable extends AircraftDrawable {
   private static final String TAG = LightPlaneDrawable.class.getSimpleName();
 
-  LightPlaneDrawable(Context context, Aircraft aircraft) {
-    setId(aircraft.getId());
-    setPosition(aircraft.getPosition());
-    setRadius(aircraft.getRadius());
-    setPaintColor(context.getResources().getColor(R.color.lightAircraft));
+  LightPlaneDrawable(Context context, float scale, Aircraft aircraft) {
+    super(aircraft.getId(), aircraft.getPosition(), aircraft.getRadius(), aircraft.getDirection(),
+        scale, context.getResources().getColor(R.color.lightAircraft));
   }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/LongRunwayDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/LongRunwayDrawable.java
@@ -12,16 +12,15 @@ public class LongRunwayDrawable extends LandingSiteDrawable {
   private static final String TAG = LongRunwayDrawable.class.getSimpleName();
   private static final float LENGTH_MULTIPLIER = 6;
 
-  // Dimensions of the Runway. Width is common to all.
+  // Dimensions of the Runway. The Main Measurement (common to all) is the Width.
   private float mLength;
 
   // Facing direction.
   private double mAngle;
 
-  LongRunwayDrawable(Context context, LongRunway runway) {
-    setPosition(runway.getPosition());
-    setPaintColor(context.getResources().getColor(R.color.landingSite));
-    mLength = LENGTH_MULTIPLIER * WIDTH;
+  LongRunwayDrawable(Context context, float scale, LongRunway runway) {
+    super(scale, runway.getPosition(), context.getResources().getColor(R.color.landingSite));
+    mLength = LENGTH_MULTIPLIER * getMeasurement();
     // Drawable faces the opposite direction of the center Angle.
     mAngle = runway.getCenterAngle() - Math.PI;
   }
@@ -31,7 +30,7 @@ public class LongRunwayDrawable extends LandingSiteDrawable {
     canvas.save();
     canvas.translate((float) getPosition().getX(), (float) getPosition().getY());
     canvas.rotate((float) Math.toDegrees(mAngle));
-    canvas.drawRect(-mLength, -WIDTH/2, 0, WIDTH/2, getPaint());
+    canvas.drawRect(-mLength, -getMeasurement()/2, 0, getMeasurement()/2, getPaint());
     canvas.restore();
   }
 }

--- a/app/src/main/java/mas/german/landingplanes/view/ShortRunwayDrawable.java
+++ b/app/src/main/java/mas/german/landingplanes/view/ShortRunwayDrawable.java
@@ -12,16 +12,15 @@ public class ShortRunwayDrawable extends LandingSiteDrawable {
   private static final String TAG = ShortRunwayDrawable.class.getSimpleName();
   private static final float LENGTH_MULTIPLIER = 4;
 
-  // Dimensions of the Runway. Width is common to all.
+  // Dimensions of the Runway. The Main Measurement (common to all) is the Width.
   private float mLength;
 
   // Facing direction.
   private double mAngle;
 
-  ShortRunwayDrawable(Context context, ShortRunway runway) {
-    setPosition(runway.getPosition());
-    setPaintColor(context.getResources().getColor(R.color.landingSite));
-    mLength = LENGTH_MULTIPLIER * WIDTH;
+  ShortRunwayDrawable(Context context, float scale, ShortRunway runway) {
+    super(scale, runway.getPosition(), context.getResources().getColor(R.color.landingSite));
+    mLength = LENGTH_MULTIPLIER * getMeasurement();
     // Drawable faces the opposite direction of the center Angle.
     mAngle = runway.getCenterAngle() - Math.PI;
   }
@@ -31,7 +30,7 @@ public class ShortRunwayDrawable extends LandingSiteDrawable {
     canvas.save();
     canvas.translate((float) getPosition().getX(), (float) getPosition().getY());
     canvas.rotate((float) Math.toDegrees(mAngle));
-    canvas.drawRect(-mLength, -WIDTH/2, 0, WIDTH/2, getPaint());
+    canvas.drawRect(-mLength, -getMeasurement()/2, 0, getMeasurement()/2, getPaint());
     canvas.restore();
   }
 }


### PR DESCRIPTION
In this PR I change the representation of the aircraft from circles to a custom path.

This led to a problem: The Aerodrome was being drawn on it's own coordinates, and this made everything look pixelated. A scale parameter is now set, which is the equivalence between the Aerodrome and the Canvas.

Before drawing anything, the scale must be set. Once this is done, the view tells the controller to initialize the game.

Also, removed a lot of duplicated code between the types of drawables.

ptal @pablisho